### PR TITLE
Parameterize echo listener address

### DIFF
--- a/echo2_integration_test.cc
+++ b/echo2_integration_test.cc
@@ -1,27 +1,31 @@
 #include "test/integration/integration.h"
 #include "test/integration/utility.h"
 
-class Echo2IntegrationTest : public BaseIntegrationTest, public testing::Test {
+class Echo2IntegrationTest : public BaseIntegrationTest,
+                             public testing::TestWithParam<Network::Address::IpVersion> {
 public:
   /**
-   * Global initializer for all integration tests.
+   * Initializer for an individual integration test.
    */
-  static void SetUpTestCase() {
-    createTestServer("echo2_server.json", {"echo"});
+  void SetUp() override {
+    createTestServer("echo2_server.json", GetParam(), {"echo"});
   }
 
   /**
-   * Global destructor for all integration tests.
+   * Destructor for an individual integration test.
    */
-  static void TearDownTestCase() {
+  void TearDown() override {
     test_server_.reset();
   }
 };
 
-TEST_F(Echo2IntegrationTest, Echo) {
+INSTANTIATE_TEST_CASE_P(IpVersions, Echo2IntegrationTest,
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+
+TEST_P(Echo2IntegrationTest, Echo) {
   Buffer::OwnedImpl buffer("hello");
   std::string response;
-  RawConnectionDriver connection(lookupPort("echo"), buffer,
+  RawConnectionDriver connection(lookupPort("echo"), GetParam(), buffer,
                                  [&](Network::ClientConnection&, const Buffer::Instance& data)
                                      -> void {
                                        response.append(TestUtility::bufferToString(data));

--- a/echo2_server.json
+++ b/echo2_server.json
@@ -1,7 +1,7 @@
 {
   "listeners": [
   {
-    "address": "tcp://127.0.0.1:0",
+    "address": "tcp://{{ ip_loopback_address }}:0",
     "use_original_dst": true,
     "filters": [
       { "type": "read", "name": "ratelimit",


### PR DESCRIPTION
This change corresponds to changes in https://github.com/lyft/envoy/pull/883 to allow for Ipv6 parameterized integration testing. In https://github.com/lyft/envoy/pull/883, we SetUp the test_server for each test rather than once in SetUpTestCase.