### PR TITLE
Fix build, update envoy git submodule ref

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -12,7 +12,7 @@ envoy_cc_binary(
     repository = "@envoy",
     deps = [
         ":echo2_config",
-        "@envoy//source/exe:envoy_main_lib",
+        "@envoy//source/exe:envoy_main_entry_lib",
     ],
 )
 


### PR DESCRIPTION
BUILD now refs envoy's envoy_main_entry_lib instead of envoy_main_lib.  Updated git submodule envoy ref to tip of  master.   See issue #11 