### PR TITLE
Improve CI testing.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -52,3 +52,9 @@ envoy_cc_test(
         "@envoy//test/integration:integration_lib"
     ],
 )
+
+sh_test(
+    name = "envoy_binary_test",
+    srcs = ["envoy_binary_test.sh"],
+    data = [":envoy"],
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -11,3 +11,6 @@ load("@envoy//bazel:cc_configure.bzl", "cc_configure")
 envoy_dependencies()
 
 cc_configure()
+
+load("@envoy_api//bazel:repositories.bzl", "api_dependencies")
+api_dependencies()

--- a/envoy_binary_test.sh
+++ b/envoy_binary_test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+#
+
+set -e
+
+# Just test that the binary was produced and can be executed.
+# envoy --help will give a success return code if working.
+envoy --help
+
+echo "PASS"


### PR DESCRIPTION
The envoy-filter-example CI did not actually verify that a runnable
binary was built since it only ran a test. A change in Envoy resulted in
the binary build from the envoy-filter-example becoming broken.

The submodule hash is updated as part of this commit.  The WORKSPACE
file is modified to include references to the api dependencies added
since the last submodule hash update.

After this is merged a commit to Envoy will update the filter-example
hash for CI to include this commit, and modify do_ci.sh to run this
new test.